### PR TITLE
fix: use uuid instead of words for bucket names

### DIFF
--- a/integration/features/storage.spec.ts
+++ b/integration/features/storage.spec.ts
@@ -492,7 +492,7 @@ class Storage extends Hooks {
   }
 
   private word() {
-    return faker.unique(faker.random.word).replace(/[^a-zA-Z0-9]/g, '')
+    return faker.unique(faker.datatype.uuid).replace(/[^a-zA-Z0-9]/g, '')
   }
 
   private createSbClient(url: string, key: string) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

- fix use uuid instead of words for bucket names in storage tests
