### PR TITLE
patch mime_types, file_size_limit now returned

### DIFF
--- a/integration/features/storage.spec.ts
+++ b/integration/features/storage.spec.ts
@@ -102,8 +102,6 @@ class Storage extends Hooks {
     log(`get bucket ${bucket.id}`)
     const { data: gotBucket, error } = await supabase.storage.getBucket(bucket.id)
     expect(error).toBeNull()
-    delete (gotBucket as any).allowed_mime_types
-    delete (gotBucket as any).file_size_limit // todo: looks wrong
     expect(gotBucket).toEqual(bucket)
   }
 
@@ -141,8 +139,6 @@ class Storage extends Hooks {
       getError = errorTemp
     }
     expect(getError).toBeNull()
-    delete (gotBucket as any).allowed_mime_types
-    delete (gotBucket as any).file_size_limit // todo: looks wrong
     expect(gotBucket).toEqual(bucket)
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- storage now returns fields that were missing
- tests were updated to respect that